### PR TITLE
Hardcode ex members urls

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -59,8 +59,19 @@ def scrape(h)
   klass.new(response: Scraped::Request.new(url: url).response)
 end
 
+def ex_members_urls
+  [
+    'http://www.parlament.mt/brincat-leo',
+    'http://www.parlament.mt/joe-cassar',
+    'http://www.parlament.mt/fenech-albert',
+  ]
+end
+
 start = 'http://www.parlament.mt/membersofparliament?l=1'
-data = scrape(start => MembersPage).member_urls.map do |url|
+data = (
+  scrape(start => MembersPage).member_urls +
+  ex_members_urls
+).map do |url|
   scrape(url => MemberPage).to_h.merge(term: 12)
 end
 

--- a/scraper.rb
+++ b/scraper.rb
@@ -40,7 +40,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :image do
-    box.css('img/@src').first.text
+    box.css('img/@src').first.text rescue nil
   end
 
   field :source do


### PR DESCRIPTION
Three members have left the legislature and are no long listed on the members page. Therefore, the scraper is no longer finding them.

However, the members' pages still exist.