### PR TITLE
Reject :electoral_history before writing

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -19,7 +19,9 @@ end
 
 start = 'http://www.parlament.mt/membersofparliament?l=1'
 data = scrape(start => MembersPage).member_urls.map do |url|
-  scrape(url => MemberPage).to_h.merge(term: 12)
+  scrape(url => MemberPage).to_h
+                           .reject { |k, _v| k == :electoral_history }
+                           .merge(term: 12)
 end
 
 # puts data


### PR DESCRIPTION
The scraper is currently broken. `:electoral_history` returns a hash but Scraperwiki cannot write this to the db. 

As we're not currently using this field, there's no need to save it. This commit removes the field before writing out to the db.