### PR TITLE
Separate name from prefixes

### DIFF
--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -9,7 +9,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :name do
-    box.css('h1').text.split(' - ').first.sub('Hon. ', '').sub(' MP', '').tidy
+    name_parts.reject { |part| titles.include? part }.map(&:tidy).join(' ')
   end
 
   field :faction do
@@ -35,6 +35,14 @@ class MemberPage < Scraped::HTML
   end
 
   private
+
+  def titles
+    %w(Dr)
+  end
+
+  def name_parts
+    box.css('h1').text.split(' - ').first.sub('Hon. ', '').sub(' MP', '').tidy.split(' ')
+  end 
 
   def box
     noko.css('div.column2')

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -13,7 +13,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :honorific_prefix do
-    name_parts.select { |part| titles.include? part }.map(&:tidy).join(';')
+    name_parts.select { |part| wanted_titles.include? part }.map(&:tidy).join(';')
   end
 
   field :faction do
@@ -40,12 +40,20 @@ class MemberPage < Scraped::HTML
 
   private
 
-  def titles
+  def wanted_titles
     %w(Dr)
   end
 
+  def unwanted_titles
+    %w(Hon. MP)
+  end
+
+  def titles
+    wanted_titles + unwanted_titles
+  end
+
   def name_parts
-    box.css('h1').text.split(' - ').first.sub('Hon. ', '').sub(' MP', '').tidy.split(' ')
+    box.css('h1').text.split(' - ').first.split(' ')
   end
 
   def box

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -12,6 +12,9 @@ class MemberPage < Scraped::HTML
     name_parts.reject { |part| titles.include? part }.map(&:tidy).join(' ')
   end
 
+  field :honorific_prefix do
+  end
+
   field :faction do
     f = box.xpath('.//strong[contains(.,"Parliamentary Group")]/..//img/@title').text
     return 'Partit Nazzjonlista' if f == 'PN'

--- a/lib/member_page.rb
+++ b/lib/member_page.rb
@@ -13,6 +13,7 @@ class MemberPage < Scraped::HTML
   end
 
   field :honorific_prefix do
+    name_parts.select { |part| titles.include? part }.map(&:tidy).join(';')
   end
 
   field :faction do
@@ -45,7 +46,7 @@ class MemberPage < Scraped::HTML
 
   def name_parts
     box.css('h1').text.split(' - ').first.sub('Hon. ', '').sub(' MP', '').tidy.split(' ')
-  end 
+  end
 
   def box
     noko.css('div.column2')

--- a/test/cassettes/AlbertFenech.yml
+++ b/test/cassettes/AlbertFenech.yml
@@ -1,0 +1,314 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.parlament.mt/fenech-albert
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 30 Jan 2017 15:47:57 GMT
+      Server:
+      - Microsoft-IIS/6.0
+      X-Powered-By:
+      - ASP.NET
+      X-Ua-Compatible:
+      - IE=EmulateIE9
+      X-Aspnet-Version:
+      - 2.0.50727
+      Set-Cookie:
+      - ASP.NET_SessionId=gfy5ti55ez1pqd55ynsg5555; path=/; HttpOnly
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '24892'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"
+        \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n<head>\r\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\r\n<link
+        rel=\"stylesheet\" type=\"text/css\" href=\"css/parlament.css\" />\r\n\r\n<!--[if
+        IE 7]>\r\n\t<link rel=\"stylesheet\" type=\"text/css\" href=\"css/ie7.css\">\r\n<![endif]-->\r\n\r\n<script
+        type=\"text/javascript\" src=\"js/jquery-1.8.2.min.js\"></script>\r\n<script
+        type=\"text/javascript\" src=\"js/jquery.cycle.js\"></script>\r\n<script type=\"text/javascript\"
+        src=\"js/general.js\"></script>\r\n<title>Parlament Ta' Malta</title>\r\n</head>\r\n\r\n<body>\r\n<form
+        name=\"aspnetForm\" method=\"post\" action=\"page.aspx?n=6F429DEE655AF8BDBEA1488376\"
+        id=\"aspnetForm\">\r\n<input type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\"
+        value=\"/wEPDwUKMTM2MTcxNzAwMA9kFgJmD2QWAmYPZBYCAgEPZBYIAgEPZBYCZg8WAh4LXyFJdGVtQ291bnQCAxYGAgEPZBYCZg8VAg9ocmVmPSJob21lP2w9MSIESG9tZWQCAw9kFgJmDxUCFWhyZWY9ImNvbnRhY3QtdXM/bD0xIgpDb250YWN0IFVzZAIFD2QWAmYPFQISaHJlZj0ic2l0ZW1hcD9sPTEiB1NpdGVtYXBkAgUPZBYCAgEPFgIfAAIFFgoCAQ9kFgRmDxUCIWhyZWY9InBhcmxpYW1lbnRhcnktYnVzaW5lc3M/bD0xIhZQYXJsaWFtZW50YXJ5IEJ1c2luZXNzZAIBDxYEHwAC/////w8eB1Zpc2libGVoZAICD2QWBGYPFQIbaHJlZj0iYWJvdXQtcGFybGlhbWVudD9sPTEiEEFib3V0IFBhcmxpYW1lbnRkAgEPFgIfAAL/////D2QCAw9kFgRmDxUCHWhyZWY9InJlZmVyZW5jZS1tYXRlcmlhbD9sPTEiElJlZmVyZW5jZSBNYXRlcmlhbGQCAQ8WBB8AAv////8PHwFoZAIED2QWBGYPFQIXaHJlZj0iZ2V0LWludm9sdmVkP2w9MSIMR2V0IEludm9sdmVkZAIBDxYEHwAC/////w8fAWhkAgUPZBYEZg8VAhpocmVmPSJsaXZlLXBhcmxpYW1lbnQ/bD0xIg9MaXZlIFBhcmxpYW1lbnRkAgEPFgQfAAL/////Dx8BaGQCBw8WAh4EVGV4dAUQRHIgQWxiZXJ0IEZlbmVjaGQCCw9kFgQCAQ8WAh8AAgUWCmYPZBYEZg8VAgVtZW51MRlQYXJsaWFtZW50YXJ5PGJyPkJ1c2luZXNzZAIDDxYCHwACBRYKAgEPZBYCZg8VAh9ocmVmPSJwYXJsYW1lbnRhcnktcmVjb3Jkcz9sPTEiF1BhcmxpYW1lbnRhcnkgRG9jdW1lbnRzZAICD2QWAmYPFQIeaHJlZj0ic3RhbmRpbmctY29tbWl0dGVlcz9sPTEiE1N0YW5kaW5nIENvbW1pdHRlZXNkAgMPZBYCZg8VAjJocmVmPSJodHRwOi8vd3d3LnBhcmxhbWVudC5tdC9zZWxjb21tLTExdGhsZWc/bD0xIhlTZWxlY3QgQ29tbWl0dGVlcyBBcmNoaXZlZAIED2QWAmYPFQI0aHJlZj0iaHR0cDovL3d3dy5wYXJsYW1lbnQubXQvcnVsaW5nbGVnaXNsYXRpb24/bD0xIgdSdWxpbmdzZAIFD2QWAmYPFQIVaHJlZj0icGxlbmFyeXNlc3Npb24iEFBsZW5hcnkgU2Vzc2lvbnNkAgEPZBYEZg8VAgVtZW51MhNBYm91dDxicj5QYXJsaWFtZW50ZAIDDxYCHwACBhYMAgEPZBYCZg8VAiJocmVmPSJjb21wb3NpdGlvbm9mcGFybGlhbWVudD9sPTEiGUNvbXBvc2l0aW9uIG9mIFBhcmxpYW1lbnRkAgIPZBYCZg8VAiJocmVmPSJsZWdpc2xhdGl2ZS1pbnN0cnVtZW50cz9sPTEiF0xlZ2lzbGF0aXZlIEluc3RydW1lbnRzZAIDD2QWAmYPFQIfaHJlZj0iaG93LXBhcmxpYW1lbnQtd29ya3M/bD0xIhRIb3cgUGFybGlhbWVudCBXb3Jrc2QCBA9kFgJmDxUCF2hyZWY9Im1pc3Npb25zdGF0ZW1lbnQiEU1pc3Npb24gU3RhdGVtZW50ZAIFD2QWAmYPFQImaHJlZj0ib2JqZWN0aXZlcy1yZXNwb25zaWJpbGl0aWVzP2w9MSIfT2JqZWN0aXZlcyBhbmQgUmVzcG9uc2liaWxpdGllc2QCBg9kFgJmDxUCF2hyZWY9ImNvZGVvZmV0aGljcz9sPTEiDkNvZGUgb2YgRXRoaWNzZAICD2QWBGYPFQIFbWVudTMVUmVmZXJlbmNlPGJyPk1hdGVyaWFsZAIDDxYCHwACAhYEAgEPZBYCZg8VAhdocmVmPSJwdWJsaWNhdGlvbnM/bD0xIgxQdWJsaWNhdGlvbnNkAgIPZBYCZg8VAh5ocmVmPSJyZWxhdGVkLWluZm9ybWF0aW9uP2w9MSITUmVsYXRlZCBJbmZvcm1hdGlvbmQCAw9kFgRmDxUCBW1lbnU0D0dldDxicj5JbnZvbHZlZGQCAw8WAh8AAgUWCgIBD2QWAmYPFQIeaHJlZj0ibWVtYmVyc29mcGFybGlhbWVudD9sPTEiD0NvbnRhY3QgeW91ciBNUGQCAg9kFgJmDxUCGGhyZWY9Im91dHJlYWNoLXByb2c/bD0xIhNPdXRyZWFjaCBQcm9ncmFtbWVzZAIDD2QWAmYPFQIWaHJlZj0ibmV3cy1ldmVudHM/bD0xIg9OZXdzIGFuZCBFdmVudHNkAgQPZBYCZg8VAh5ocmVmPSJjdWx0dXJhbC1hY3Rpdml0aWVzP2w9MSITQ3VsdHVyYWwgQWN0aXZpdGllc2QCBQ9kFgJmDxUCHWhyZWY9InB1YmxpYy1wcm9jdXJlbWVudD9sPTEiElB1YmxpYyBQcm9jdXJlbWVudGQCBA9kFgRmDxUCBW1lbnU1EmxpdmU8YnI+UGFybGlhbWVudGQCAw8WAh8AAgIWBAIBD2QWAmYPFQIaaHJlZj0ibGl2ZS1wYXJsaWFtZW50P2w9MSIOTGl2ZSBTdHJlYW1pbmdkAgIPZBYCZg8VAhRocmVmPSJhdWRpby1hcmNoaXZlIg1BdWRpbyBBcmNoaXZlZAIDDxYCHwACBRYKZg9kFgJmDxUCGWhyZWY9InByaXZhY3ktcG9saWN5P2w9MSIOUHJpdmFjeSBwb2xpY3lkAgEPZBYCZg8VAhVocmVmPSJkaXNjbGFpbWVyP2w9MSIKRGlzY2xhaW1lcmQCAg9kFgJmDxUCFGhyZWY9ImNvcHlyaWdodD9sPTEiCUNvcHlyaWdodGQCAw9kFgJmDxUCImhyZWY9ImFjY2Vzc2liaWxpdHktc3RhdGVtZW50P2w9MSIXQWNjZXNzaWJpbGl0eSBTdGF0ZW1lbnRkAgQPZBYCZg8VAhJocmVmPSJzaXRlbWFwP2w9MSIHU2l0ZW1hcGRk7+OWNdoDrQStyLyDR8lOsANVsBw=\"
+        />\r\n\r\n<input type=\"hidden\" name=\"__EVENTVALIDATION\" id=\"__EVENTVALIDATION\"
+        value=\"/wEWBgKF5ODrCAL3+pO+CwL3+o+/CwL3+ovECwL3+oe9CwL3+oPCC8JPb4QsJenIaRdiW8atv8zlyqYw\"
+        />\r\n<div id=\"topshadow\"> </div>\r\n<div id=\"contentArea\"> \r\n  \r\n
+        \ <!-- START OF HEADER -->\r\n\r\n\r\n<div id=\"header\">\r\n    <a href=\"home?l=1\"
+        title=\"Home Page\" class=\"logo\">\r\n        <img src=\"imgs/logo.gif\"
+        alt=\"Parlament Ta' Malta\" title=\"Parlament Ta' Malta Logo\"\r\n            width=\"171\"
+        height=\"92\" /></a>\r\n    <div class=\"firstRow\">\r\n        \r\n                <ul
+        class=\"sitemenu\">\r\n            \r\n                <li><a href=\"home?l=1\"=\"\">\r\n
+        \                   Home</a></li>\r\n            \r\n                <li class=\"separator\">|</li>\r\n
+        \           \r\n                <li><a href=\"contact-us?l=1\"=\"\">\r\n                    Contact
+        Us</a></li>\r\n            \r\n                <li class=\"separator\">|</li>\r\n
+        \           \r\n                <li><a href=\"sitemap?l=1\"=\"\">\r\n                    Sitemap</a></li>\r\n
+        \           \r\n                </ul>\r\n            \r\n       \r\n        \r\n
+        \      \r\n    </div>\r\n    <div class=\"secondRow\">\r\n        <a href=\"docsearch?l=1\"
+        class=\"searchButton\">\r\n            Search Site\r\n        </a>\r\n    </div>\r\n</div>\r\n\r\n
+        \ <!-- END OF HEADER --> \r\n  \r\n  <!-- MAIN CONTENT WILL BE WRAPPED IN
+        A DIV FOR ANY NECCESSARY CSS CONTROL -->\r\n  <div id=\"contentWrapper\">
+        \r\n    <!-- START OF MAIN LEFT COLUMN -->\r\n    <div id=\"mainContent\"
+        class=\"wideTemplate\">\r\n      <div id=\"mainmenu\">\r\n<ul>\r\n<li><a href=\"parliamentary-business?l=1\">Parliamentary<br
+        />Business</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a class=\"subheader\"
+        href=\"parlamentary-records?l=1\">Parliamentary Documents</a>\r\n<ul>\r\n<li><a
+        href=\"sittinglegislation?l=1\">Parliamentary sessions</a></li>\r\n<li><a
+        href=\"http://pq.gov.mt/?l=1\" target=\"_blank\">Parliamentary Questions</a></li>\r\n<li><a
+        href=\"actslegislation?l=1\">Acts of Parliament</a></li>\r\n<li><a href=\"billslegislation?l=1\">Bills</a></li>\r\n<li><a
+        href=\"paperslaidcat?l=1\">Papers laid</a></li>\r\n<li><a href=\"statementlegislation?l=1\">Ministerial
+        Statements</a></li>\r\n<li><a href=\"motionlegislation?l=1\">Motions</a></li>\r\n<li><a
+        href=\"petitionlegislation?l=1\">Petitions</a></li>\r\n<li><a href=\"rulinglegislation?l=1\">Rulings</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span
+        class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a class=\"subheader\" href=\"standing-committees?l=1\">Standing
+        Committees</a>\r\n<ul>\r\n<li><a href=\"housebusinesscommittee?l=1\">House
+        Business Committee</a></li>\r\n<li><a href=\"privilegescommittee?l=1\">Privileges
+        Committee</a></li>\r\n<li><a href=\"publicaccountscommittee?l=1\">Public Accounts
+        Committee</a></li>\r\n<li><a href=\"foreignandeuropeanaffairscommittee?l=1\">Foreign
+        and European Affairs Committee</a></li>\r\n<li><a href=\"socialaffairscommittee?l=1\">Social
+        Affairs Committee</a></li>\r\n<li><a href=\"familyaffaircommittee?l=1\">Family
+        Affairs Committee</a></li>\r\n<li><a href=\"economicandfinancialaffairscommittee?l=1\">Economic
+        and Financial Affairs Committee</a></li>\r\n<li><a href=\"healthcommittee?l=1\">Health
+        Committee</a></li>\r\n<li><a href=\"considerationofbillscommittee?l=1\">Consideration
+        of Bills Committee</a></li>\r\n<li><a href=\"nationalauditofficeaccountscommittee?l=1\">National
+        Audit Office Accounts Committee</a></li>\r\n<li><a href=\"developmentplanning?l=1\">Environment
+        and Development Planning Committee</a></li>\r\n<li><a href=\"capitalofculture?l=1\">Parliamentary
+        Group on the European Capital of Culture</a></li>\r\n<li><a href=\"adjunctconsiderationofbillscommittee?l=1\">Adjunct
+        Consideration of Bills Committee</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span
+        class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a class=\"subheader\">Select
+        Committees</a>\r\n<ul>\r\n<li><a href=\"selectcomm?l=1\">Select Committee
+        on the appointment of a commissioner and a standing committee on standards,
+        ethics and proper behaviour in public life</a></li>\r\n<li><a href=\"selcomm-11thleg?l=1\">Select
+        Committees - Archive<br /><br /></a></li>\r\n</ul>\r\n</li>\r\n<li><a class=\"subheader\"
+        href=\"parliamentary-delegations?l=1\">Parliamentary Delegations</a>\r\n<ul>\r\n<li><a
+        href=\"pace\">Parliamentary Assembly of the Council of Europe</a></li>\r\n<li><a
+        href=\"ipu\">Inter Parliamentary Union</a></li>\r\n<li><a href=\"pam\">Parliamentary
+        Assembly of the Mediterranean</a></li>\r\n<li><a href=\"paum\">Parliamentary
+        Assembly of the Union for the Mediterranean</a></li>\r\n<li><a href=\"osce\">Parliamentary
+        Assembly of the OSCE</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</div>\r\n</li>\r\n<li><a
+        href=\"about-parliament?l=1\">About<br />Parliament</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a
+        class=\"subheader\" href=\"compositionofparliament?l=1\">Composition of Parliament</a>\r\n<ul>\r\n<li><a
+        href=\"http://www.president.gov.mt/mt/Pages/default.aspx\" target=\"_blank\">The
+        President of Malta</a></li>\r\n<li><a href=\"speaker?l=1\">Mr Speaker</a></li>\r\n<li><a
+        href=\"membersofparliament?l=1\">Members of Parliament</a></li>\r\n<li><a
+        href=\"meps?l=1\">Members of European Parliament</a></li>\r\n<li><a href=\"former-mps?l=1\">Association
+        of Former Members of Parliament</a></li>\r\n<li><a href=\"formerspeakers?l=1\">Former
+        Speakers of the House of Representatives</a></li>\r\n</ul>\r\n</li>\r\n<li><a
+        class=\"subheader\" href=\"legislative-instruments?l=1\">Legislative Instruments</a>\r\n<ul>\r\n<li><a
+        href=\"constituion-of-malta?l=1\">Constitution of Malta</a></li>\r\n<li><a
+        href=\"standing-orders?l=1\">Standing Orders</a></li>\r\n<li><a href=\"house-of-representatives?l=1\">House
+        Of Representatives (Privileges and Powers) Ordinance (Cap 113)</a></li>\r\n<li><a
+        href=\"general_election_act?l=1\">General Elections Act (Cap 354)</a></li>\r\n<li><a
+        href=\"electoral-ordinance?l=1\">Electoral (Polling) Ordinance (Cap 102)</a></li>\r\n<li><a
+        href=\"mps-publicemployment?l=1\">Members of Parliament (Public Employment)
+        Act (Cap 472)</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a
+        class=\"subheader\" href=\"how-parliament-works?l=1\">How Parliament Works<br
+        /></a>\r\n<ul>\r\n<li><a href=\"historicalbackground?l=1\">Historical Background</a></li>\r\n<li><a
+        href=\"thepractiseofparliament?l=1\">Parliament Practice</a></li>\r\n<li><a
+        href=\"parliamentaryprocedures?l=1\">Parliament Procedures</a></li>\r\n<li><a
+        href=\"legislativeprocess?l=1\">Legislative Process</a></li>\r\n</ul>\r\n</li>\r\n<li><a
+        class=\"subheader\" href=\"missionstatement?l=1\">Mission Statement</a></li>\r\n<li><a
+        class=\"subheader\" href=\"objectives-responsibilities?l=1\">Objectives and
+        Responsibilities</a></li>\r\n<li><a class=\"subheader\" href=\"codeofethics?l=1\">Code
+        of Ethics</a>\r\n<ul>\r\n<li><a href=\"codeofethics-mp?l=1\">Members of Parliament</a></li>\r\n<li><a
+        href=\"codeofethics-ministers?l=1\">Ministers, Parliamentary Secretaries and
+        Parliamentary Assistants</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</div>\r\n</li>\r\n<li
+        class=\"separator\">&nbsp;</li>\r\n<li><a href=\"reference-material?l=1\">Reference<br
+        />Material</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a class=\"subheader\"
+        href=\"publications?l=1\">Publications</a>\r\n<ul>\r\n<li><a href=\"mill-parlament?l=1&quot;\">mill-Parlament
+        - Periodical</a></li>\r\n<li><a href=\"annual-reports?l=1\">Annual Report</a></li>\r\n<li><a
+        href=\"reports-parliament?l=1\">Reports published by the Speaker - 11th Legislature</a></li>\r\n<li><a
+        href=\"committee-reports?l=1\">Reports by Committees</a></li>\r\n<li><a href=\"mps-passedaway?l=1\">Commemoration
+        of Members of Parliament who passed away</a></li>\r\n<li><a href=\"health-choices\">Health
+        Choices - Proposals of the Parliamentary Working Group on Diabetes Mellitus</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span
+        class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a class=\"subheader\" href=\"related-information?l=1\">Related
+        Information</a>\r\n<ul>\r\n<li><a href=\"links?l=1\">Links</a></li>\r\n<li><a
+        href=\"fredomofinformation?l=1\">Access to Documents (Freedom of Information</a></li>\r\n<li><a
+        href=\"information-material?l=1\">Information Material</a></li>\r\n<li><a
+        href=\"memoranda-11thleg\">11th Leg Memoranda</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</div>\r\n</li>\r\n<li
+        class=\"separator\">&nbsp;</li>\r\n<li><a href=\"get-involved?l=1\">Get<br
+        />Involved</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a class=\"subheader\"
+        href=\"membersofparliament?l=1\">Contact Your MP</a></li>\r\n<li><a class=\"subheader\"
+        href=\"outreach-prog?l=1\">Outreach Programmes</a></li>\r\n<li><a class=\"subheader\"
+        href=\"news-events?l=1\">News and Events</a>\r\n<ul>\r\n<li><a href=\"news?l=1\">Archive</a></li>\r\n<li><a
+        href=\"press-releases?l=1\">Press Releases</a></li>\r\n</ul>\r\n</li>\r\n<li><a
+        class=\"subheader\" href=\"cultural-activities?l=1\">Cultural Activities</a></li>\r\n<li><a
+        class=\"subheader\" href=\"public-procurement\">Public Procurement</a></li>\r\n</ul>\r\n</div>\r\n</li>\r\n</ul>\r\n</div>\r\n\r\n
+        \     <div id=\"subpageContent\" class=\"oldTemplate\">\r\n        <div class=\"column1\">\r\n
+        \           \r\n<table width=\"213\" border=\"0\" cellPadding=\"0\" cellSpacing=\"0\"
+        summary=\"Design Layout\" >\r\n\t<tr>\r\n\t\t<td height=\"20\">\r\n\t\t    \r\n\t
+        \               <table width=\"212\" border=\"0\" cellPadding=\"0\" cellSpacing=\"0\"
+        summary=\"Design Layout\" >\r\n\t                <tr>\r\n\t\t                <td>\r\n\t\t
+        \                   <table width=\"212\" border=\"0\" cellPadding=\"0\" cellSpacing=\"0\"
+        id=\"submenu\" summary=\"Design Layout\">\r\n\t\t\t                    <tr>\r\n\t\t\t\t
+        \                   <td><IMG height=\"36\" src=\"imgs/tab_relatedinfo.gif\"
+        width=\"300\" alt=\"Related Info\"></td>\r\n\t\t\t                    </tr>\r\n\t\t
+        \                   </table>\r\n\t\t                </td>\r\n\t\t            </tr>\t\t
+        \           \r\n\t\t        \r\n\t\t\t\t    \r\n\t\t\t\t    <tr>\r\n\t\t\t\t
+        \       <td>\r\n\t\t\t\t\t        <table width=\"100%\" border=\"0\" cellpadding=\"0\"
+        cellspacing=\"0\" bgcolor=\"#ebebeb\" summary=\"Design Layout\">\r\n\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t\t        <tr height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t
+        \       <td width=\"27\" class=\"arrowcell\" ><img src=\"imgs/arrow_red.gif\"
+        alt=\"Arrow\" width=\"17\" height=\"13\" hspace=\"2\" vspace=\"2\"></td><td
+        align=\"left\" width=\"185\"><a class=\"MenuTextLink\" href=\"parliamentary-business?l=1\">Parliamentary
+        Business</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t        \r\n\t\t\t\t\t
+        \       </table>\r\n\t\t                </td>\r\n\t\t            </tr>\r\n\t\t\t\t\r\n\t\t\t\t
+        \   \r\n\t\t\t        <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <div
+        align=\"left\"><IMG src=\"pics/navigation_seperator.gif\" alt=\"Seperator\"
+        width=\"300\" height=\"5\"></div>\r\n\t\t\t\t        </td>\r\n\t\t\t        </tr>\r\n\t\t\t
+        \       \r\n\t\t\t\t    <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <table
+        width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" bgcolor=\"#ebebeb\"
+        summary=\"Design Layout\">\r\n\t\t\t\t\t\t        \r\n\t\t\t\t\t\t        <tr
+        height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t        <td width=\"27\" class=\"arrowcell\"
+        ><img src=\"imgs/arrow_red.gif\" alt=\"Arrow\" width=\"17\" height=\"13\"
+        hspace=\"2\" vspace=\"2\"></td><td align=\"left\" width=\"185\"><a class=\"MenuTextLink\"
+        href=\"about-parliament?l=1\">About Parliament</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t        </table>\r\n\t\t                </td>\r\n\t\t
+        \           </tr>\r\n\t\t\t\t\r\n\t\t\t\t    \r\n\t\t\t        <tr>\r\n\t\t\t\t
+        \       <td>\r\n\t\t\t\t\t        <div align=\"left\"><IMG src=\"pics/navigation_seperator.gif\"
+        alt=\"Seperator\" width=\"300\" height=\"5\"></div>\r\n\t\t\t\t        </td>\r\n\t\t\t
+        \       </tr>\r\n\t\t\t        \r\n\t\t\t\t    <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t
+        \       <table width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"
+        bgcolor=\"#ebebeb\" summary=\"Design Layout\">\r\n\t\t\t\t\t\t        \r\n\t\t\t\t\t\t
+        \       <tr height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t        <td width=\"27\"
+        class=\"arrowcell\" ><img src=\"imgs/arrow_red.gif\" alt=\"Arrow\" width=\"17\"
+        height=\"13\" hspace=\"2\" vspace=\"2\"></td><td align=\"left\" width=\"185\"><a
+        class=\"MenuTextLink\" href=\"reference-material?l=1\">Reference Material</a></td>\r\n\t\t\t\t\t\t
+        \       </tr>\r\n\t\t\t\t\t\t\t        \r\n\t\t\t\t\t        </table>\r\n\t\t
+        \               </td>\r\n\t\t            </tr>\r\n\t\t\t\t\r\n\t\t\t\t    \r\n\t\t\t
+        \       <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <div align=\"left\"><IMG
+        src=\"pics/navigation_seperator.gif\" alt=\"Seperator\" width=\"300\" height=\"5\"></div>\r\n\t\t\t\t
+        \       </td>\r\n\t\t\t        </tr>\r\n\t\t\t        \r\n\t\t\t\t    <tr>\r\n\t\t\t\t
+        \       <td>\r\n\t\t\t\t\t        <table width=\"100%\" border=\"0\" cellpadding=\"0\"
+        cellspacing=\"0\" bgcolor=\"#ebebeb\" summary=\"Design Layout\">\r\n\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t\t        <tr height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t
+        \       <td width=\"27\" class=\"arrowcell\" ><img src=\"imgs/arrow_red.gif\"
+        alt=\"Arrow\" width=\"17\" height=\"13\" hspace=\"2\" vspace=\"2\"></td><td
+        align=\"left\" width=\"185\"><a class=\"MenuTextLink\" href=\"get-involved?l=1\">Get
+        Involved</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t        \r\n\t\t\t\t\t
+        \       </table>\r\n\t\t                </td>\r\n\t\t            </tr>\r\n\t\t\t\t\r\n\t\t\t\t
+        \   \r\n\t\t\t        <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <div
+        align=\"left\"><IMG src=\"pics/navigation_seperator.gif\" alt=\"Seperator\"
+        width=\"300\" height=\"5\"></div>\r\n\t\t\t\t        </td>\r\n\t\t\t        </tr>\r\n\t\t\t
+        \       \r\n\t\t\t\t    <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <table
+        width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" bgcolor=\"#ebebeb\"
+        summary=\"Design Layout\">\r\n\t\t\t\t\t\t        \r\n\t\t\t\t\t\t        <tr
+        height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t        <td width=\"27\" class=\"arrowcell\"
+        ><img src=\"imgs/arrow_red.gif\" alt=\"Arrow\" width=\"17\" height=\"13\"
+        hspace=\"2\" vspace=\"2\"></td><td align=\"left\" width=\"185\"><a class=\"MenuTextLink\"
+        href=\"live-parliament?l=1\">Live Parliament</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t        </table>\r\n\t\t                </td>\r\n\t\t
+        \           </tr>\r\n\t\t\t\t\r\n\t\t\t\t</table>\r\n\t\t\t\t\r\n\t\t</td>\r\n\t</tr>\r\n</table>\r\n\r\n
+        \       </div>\r\n      \t<div class=\"column2\">\r\n      \t    <h1>Dr Albert
+        Fenech</h1>\r\n            <table style=\"height: 31px; width: 543px;\" border=\"0\"
+        align=\"left\">\r\n<tbody>\r\n<tr>\r\n<td dir=\"ltr\" align=\"left\" valign=\"bottom\"><img
+        title=\"Albert Fenech\" src=\"file.aspx?f=33193\" alt=\"Albert Fenech\" width=\"152\"
+        height=\"204\" /></td>\r\n<td style=\"width: 880px;\" valign=\"bottom\">\r\n<p><strong><strong><br
+        /></strong></strong>&nbsp;</p>\r\n</td>\r\n</tr>\r\n<tr>\r\n<td valign=\"top\"><hr
+        /><span style=\"color: #003300;\"><strong>Contact Details:</strong></span></td>\r\n<td><hr
+        /><span style=\"color: #000000;\"><strong>Address:<br /></strong></span><span
+        style=\"color: #000000;\">House of Representatives <br />Republic Street<br
+        /></span><span style=\"color: #000000;\">Valletta<br /><br /><strong>Email:<br
+        /></strong><span style=\"color: #3366ff;\"><a href=\"mailto:albert.fenech@gov.mt\"><span
+        style=\"color: #3366ff;\">albert.fenech@gov.mt</span></a></span></span></td>\r\n</tr>\r\n<tr>\r\n<td
+        valign=\"top\"><hr /><span style=\"color: #003300;\"><strong>Electoral History:</strong></span></td>\r\n<td><hr
+        /><span style=\"color: #000000;\"><span style=\"text-decoration: underline;\"><strong>Twelfth
+        Parliament</strong></span><strong>:</strong></span><br /><br /><span style=\"color:
+        #000000;\">Elected by casual elections on: 03.04.13<br /></span><span style=\"color:
+        #000000;\">Oath of Allegiance: 06.04.13<br />Resignation from Parliament:
+        05.04.16</span></td>\r\n</tr>\r\n<tr>\r\n<td valign=\"top\"><hr /></td>\r\n<td><hr
+        /></td>\r\n</tr>\r\n</tbody>\r\n</table>\r\n<p>&nbsp;</p>\r\n<p>&nbsp;</p>\r\n
+        \     \t</div>\r\n      </div>      \r\n    </div>\r\n    <!-- END OF MAIN
+        LEFT COLUMN -->\r\n    \r\n  \r\n  <!-- #### Footer #### -->\r\n\r\n<div id=\"footer\">\r\n
+        \   <div class=\"quicknav\">\r\n        \r\n                <div class=\"menu1\">\r\n
+        \                   <h5>\r\n                        Parliamentary<br>Business</h5>\r\n
+        \                        <input type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl0:hdnID\"
+        id=\"_ctl0_footer_rpt__ctl0_hdnID\" value=\"237\" />\r\n                    \r\n
+        \                           <ul>\r\n                        \r\n                            <li><a
+        href=\"parlamentary-records?l=1\"=\"\">\r\n                                Parliamentary
+        Documents</a></li>\r\n                        \r\n                            <li><a
+        href=\"standing-committees?l=1\"=\"\">\r\n                                Standing
+        Committees</a></li>\r\n                        \r\n                            <li><a
+        href=\"http://www.parlament.mt/selcomm-11thleg?l=1\"=\"\">\r\n                                Select
+        Committees Archive</a></li>\r\n                        \r\n                            <li><a
+        href=\"http://www.parlament.mt/rulinglegislation?l=1\"=\"\">\r\n                                Rulings</a></li>\r\n
+        \                       \r\n                            <li><a href=\"plenarysession\"=\"\">\r\n
+        \                               Plenary Sessions</a></li>\r\n                        \r\n
+        \                           </ul>\r\n                        \r\n                </div>\r\n
+        \           \r\n                <div class=\"menu2\">\r\n                    <h5>\r\n
+        \                       About<br>Parliament</h5>\r\n                         <input
+        type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl1:hdnID\" id=\"_ctl0_footer_rpt__ctl1_hdnID\"
+        value=\"238\" />\r\n                    \r\n                            <ul>\r\n
+        \                       \r\n                            <li><a href=\"compositionofparliament?l=1\"=\"\">\r\n
+        \                               Composition of Parliament</a></li>\r\n                        \r\n
+        \                           <li><a href=\"legislative-instruments?l=1\"=\"\">\r\n
+        \                               Legislative Instruments</a></li>\r\n                        \r\n
+        \                           <li><a href=\"how-parliament-works?l=1\"=\"\">\r\n
+        \                               How Parliament Works</a></li>\r\n                        \r\n
+        \                           <li><a href=\"missionstatement\"=\"\">\r\n                                Mission
+        Statement</a></li>\r\n                        \r\n                            <li><a
+        href=\"objectives-responsibilities?l=1\"=\"\">\r\n                                Objectives
+        and Responsibilities</a></li>\r\n                        \r\n                            <li><a
+        href=\"codeofethics?l=1\"=\"\">\r\n                                Code of
+        Ethics</a></li>\r\n                        \r\n                            </ul>\r\n
+        \                       \r\n                </div>\r\n            \r\n                <div
+        class=\"menu3\">\r\n                    <h5>\r\n                        Reference<br>Material</h5>\r\n
+        \                        <input type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl2:hdnID\"
+        id=\"_ctl0_footer_rpt__ctl2_hdnID\" value=\"239\" />\r\n                    \r\n
+        \                           <ul>\r\n                        \r\n                            <li><a
+        href=\"publications?l=1\"=\"\">\r\n                                Publications</a></li>\r\n
+        \                       \r\n                            <li><a href=\"related-information?l=1\"=\"\">\r\n
+        \                               Related Information</a></li>\r\n                        \r\n
+        \                           </ul>\r\n                        \r\n                </div>\r\n
+        \           \r\n                <div class=\"menu4\">\r\n                    <h5>\r\n
+        \                       Get<br>Involved</h5>\r\n                         <input
+        type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl3:hdnID\" id=\"_ctl0_footer_rpt__ctl3_hdnID\"
+        value=\"240\" />\r\n                    \r\n                            <ul>\r\n
+        \                       \r\n                            <li><a href=\"membersofparliament?l=1\"=\"\">\r\n
+        \                               Contact your MP</a></li>\r\n                        \r\n
+        \                           <li><a href=\"outreach-prog?l=1\"=\"\">\r\n                                Outreach
+        Programmes</a></li>\r\n                        \r\n                            <li><a
+        href=\"news-events?l=1\"=\"\">\r\n                                News and
+        Events</a></li>\r\n                        \r\n                            <li><a
+        href=\"cultural-activities?l=1\"=\"\">\r\n                                Cultural
+        Activities</a></li>\r\n                        \r\n                            <li><a
+        href=\"public-procurement?l=1\"=\"\">\r\n                                Public
+        Procurement</a></li>\r\n                        \r\n                            </ul>\r\n
+        \                       \r\n                </div>\r\n            \r\n                <div
+        class=\"menu5\">\r\n                    <h5>\r\n                        live<br>Parliament</h5>\r\n
+        \                        <input type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl4:hdnID\"
+        id=\"_ctl0_footer_rpt__ctl4_hdnID\" value=\"241\" />\r\n                    \r\n
+        \                           <ul>\r\n                        \r\n                            <li><a
+        href=\"live-parliament?l=1\"=\"\">\r\n                                Live
+        Streaming</a></li>\r\n                        \r\n                            <li><a
+        href=\"audio-archive\"=\"\">\r\n                                Audio Archive</a></li>\r\n
+        \                       \r\n                            </ul>\r\n                        \r\n
+        \               </div>\r\n            \r\n    </div>\r\n    <div class=\"footerlinks\">\r\n
+        \      \r\n        \r\n        <a href=\"privacy-policy?l=1\"=\"\">\r\n                                Privacy
+        policy</a>\r\n        \r\n        <a href=\"disclaimer?l=1\"=\"\">\r\n                                Disclaimer</a>\r\n
+        \       \r\n        <a href=\"copyright?l=1\"=\"\">\r\n                                Copyright</a>\r\n
+        \       \r\n        <a href=\"accessibility-statement?l=1\"=\"\">\r\n                                Accessibility
+        Statement</a>\r\n        \r\n        <a href=\"sitemap?l=1\"=\"\">\r\n                                Sitemap</a>\r\n
+        \       \r\n        \r\n    </div>\r\n</div>\r\n\r\n  <div id=\"alertsignature\">
+        <a href=\"http://www.alert.com.mt\">\r\n      <img id=\"_ctl0_imgAlert\" title=\"Alert
+        Logo\" src=\"imgs/design_dev_1.jpg\" border=\"0\" height=\"43\" width=\"371\"
+        /></a> </div>\r\n</div>\r\n</div>\r\n</form>\r\n</body>\r\n</html>\r\n\r\n"
+    http_version: 
+  recorded_at: Mon, 30 Jan 2017 15:43:53 GMT
+recorded_with: VCR 3.0.3

--- a/test/cassettes/IanBorg.yml
+++ b/test/cassettes/IanBorg.yml
@@ -1,0 +1,334 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.parlament.mt/borg-ian
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Tue, 07 Feb 2017 14:44:00 GMT
+      Server:
+      - Microsoft-IIS/6.0
+      X-Powered-By:
+      - ASP.NET
+      X-Ua-Compatible:
+      - IE=EmulateIE9
+      X-Aspnet-Version:
+      - 2.0.50727
+      Set-Cookie:
+      - ASP.NET_SessionId=oue15dedpjqzykzkaqzrdpau; path=/; HttpOnly
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/html; charset=utf-8
+      Content-Length:
+      - '27256'
+    body:
+      encoding: UTF-8
+      string: "\r\n\r\n<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\"
+        \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">\r\n<html xmlns=\"http://www.w3.org/1999/xhtml\">\r\n<head>\r\n<meta
+        http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />\r\n<link
+        rel=\"stylesheet\" type=\"text/css\" href=\"css/parlament.css\" />\r\n\r\n<!--[if
+        IE 7]>\r\n\t<link rel=\"stylesheet\" type=\"text/css\" href=\"css/ie7.css\">\r\n<![endif]-->\r\n\r\n<script
+        type=\"text/javascript\" src=\"js/jquery-1.8.2.min.js\"></script>\r\n<script
+        type=\"text/javascript\" src=\"js/jquery.cycle.js\"></script>\r\n<script type=\"text/javascript\"
+        src=\"js/general.js\"></script>\r\n<title>Parlament Ta' Malta</title>\r\n</head>\r\n\r\n<body>\r\n<form
+        name=\"aspnetForm\" method=\"post\" action=\"page.aspx?n=6B4881EC2B5BB4B2\"
+        id=\"aspnetForm\">\r\n<input type=\"hidden\" name=\"__VIEWSTATE\" id=\"__VIEWSTATE\"
+        value=\"/wEPDwUKMTM2MTcxNzAwMA9kFgJmD2QWAmYPZBYCAgEPZBYIAgEPZBYCZg8WAh4LXyFJdGVtQ291bnQCAxYGAgEPZBYCZg8VAg9ocmVmPSJob21lP2w9MSIESG9tZWQCAw9kFgJmDxUCFWhyZWY9ImNvbnRhY3QtdXM/bD0xIgpDb250YWN0IFVzZAIFD2QWAmYPFQISaHJlZj0ic2l0ZW1hcD9sPTEiB1NpdGVtYXBkAgUPZBYCAgEPFgIfAAIFFgoCAQ9kFgRmDxUCIWhyZWY9InBhcmxpYW1lbnRhcnktYnVzaW5lc3M/bD0xIhZQYXJsaWFtZW50YXJ5IEJ1c2luZXNzZAIBDxYEHwAC/////w8eB1Zpc2libGVoZAICD2QWBGYPFQIbaHJlZj0iYWJvdXQtcGFybGlhbWVudD9sPTEiEEFib3V0IFBhcmxpYW1lbnRkAgEPFgIfAAL/////D2QCAw9kFgRmDxUCHWhyZWY9InJlZmVyZW5jZS1tYXRlcmlhbD9sPTEiElJlZmVyZW5jZSBNYXRlcmlhbGQCAQ8WBB8AAv////8PHwFoZAIED2QWBGYPFQIXaHJlZj0iZ2V0LWludm9sdmVkP2w9MSIMR2V0IEludm9sdmVkZAIBDxYEHwAC/////w8fAWhkAgUPZBYEZg8VAhpocmVmPSJsaXZlLXBhcmxpYW1lbnQ/bD0xIg9MaXZlIFBhcmxpYW1lbnRkAgEPFgQfAAL/////Dx8BaGQCBw8WAh4EVGV4dAVLSG9uLiBJYW4gQm9yZyBNUCAtIFBhcmxpYW1lbnRhcnkgU2VjcmV0YXJ5IGZvciBFVSBmdW5kcyBhbmQgMjAxNyBQcmVzaWRlbmN5ZAILD2QWBAIBDxYCHwACBRYKZg9kFgRmDxUCBW1lbnUxGVBhcmxpYW1lbnRhcnk8YnI+QnVzaW5lc3NkAgMPFgIfAAIFFgoCAQ9kFgJmDxUCH2hyZWY9InBhcmxhbWVudGFyeS1yZWNvcmRzP2w9MSIXUGFybGlhbWVudGFyeSBEb2N1bWVudHNkAgIPZBYCZg8VAh5ocmVmPSJzdGFuZGluZy1jb21taXR0ZWVzP2w9MSITU3RhbmRpbmcgQ29tbWl0dGVlc2QCAw9kFgJmDxUCMmhyZWY9Imh0dHA6Ly93d3cucGFybGFtZW50Lm10L3NlbGNvbW0tMTF0aGxlZz9sPTEiGVNlbGVjdCBDb21taXR0ZWVzIEFyY2hpdmVkAgQPZBYCZg8VAjRocmVmPSJodHRwOi8vd3d3LnBhcmxhbWVudC5tdC9ydWxpbmdsZWdpc2xhdGlvbj9sPTEiB1J1bGluZ3NkAgUPZBYCZg8VAhVocmVmPSJwbGVuYXJ5c2Vzc2lvbiIQUGxlbmFyeSBTZXNzaW9uc2QCAQ9kFgRmDxUCBW1lbnUyE0Fib3V0PGJyPlBhcmxpYW1lbnRkAgMPFgIfAAIGFgwCAQ9kFgJmDxUCImhyZWY9ImNvbXBvc2l0aW9ub2ZwYXJsaWFtZW50P2w9MSIZQ29tcG9zaXRpb24gb2YgUGFybGlhbWVudGQCAg9kFgJmDxUCImhyZWY9ImxlZ2lzbGF0aXZlLWluc3RydW1lbnRzP2w9MSIXTGVnaXNsYXRpdmUgSW5zdHJ1bWVudHNkAgMPZBYCZg8VAh9ocmVmPSJob3ctcGFybGlhbWVudC13b3Jrcz9sPTEiFEhvdyBQYXJsaWFtZW50IFdvcmtzZAIED2QWAmYPFQIXaHJlZj0ibWlzc2lvbnN0YXRlbWVudCIRTWlzc2lvbiBTdGF0ZW1lbnRkAgUPZBYCZg8VAiZocmVmPSJvYmplY3RpdmVzLXJlc3BvbnNpYmlsaXRpZXM/bD0xIh9PYmplY3RpdmVzIGFuZCBSZXNwb25zaWJpbGl0aWVzZAIGD2QWAmYPFQIXaHJlZj0iY29kZW9mZXRoaWNzP2w9MSIOQ29kZSBvZiBFdGhpY3NkAgIPZBYEZg8VAgVtZW51MxVSZWZlcmVuY2U8YnI+TWF0ZXJpYWxkAgMPFgIfAAICFgQCAQ9kFgJmDxUCF2hyZWY9InB1YmxpY2F0aW9ucz9sPTEiDFB1YmxpY2F0aW9uc2QCAg9kFgJmDxUCHmhyZWY9InJlbGF0ZWQtaW5mb3JtYXRpb24/bD0xIhNSZWxhdGVkIEluZm9ybWF0aW9uZAIDD2QWBGYPFQIFbWVudTQPR2V0PGJyPkludm9sdmVkZAIDDxYCHwACBRYKAgEPZBYCZg8VAh5ocmVmPSJtZW1iZXJzb2ZwYXJsaWFtZW50P2w9MSIPQ29udGFjdCB5b3VyIE1QZAICD2QWAmYPFQIYaHJlZj0ib3V0cmVhY2gtcHJvZz9sPTEiE091dHJlYWNoIFByb2dyYW1tZXNkAgMPZBYCZg8VAhZocmVmPSJuZXdzLWV2ZW50cz9sPTEiD05ld3MgYW5kIEV2ZW50c2QCBA9kFgJmDxUCHmhyZWY9ImN1bHR1cmFsLWFjdGl2aXRpZXM/bD0xIhNDdWx0dXJhbCBBY3Rpdml0aWVzZAIFD2QWAmYPFQIdaHJlZj0icHVibGljLXByb2N1cmVtZW50P2w9MSISUHVibGljIFByb2N1cmVtZW50ZAIED2QWBGYPFQIFbWVudTUSbGl2ZTxicj5QYXJsaWFtZW50ZAIDDxYCHwACAhYEAgEPZBYCZg8VAhpocmVmPSJsaXZlLXBhcmxpYW1lbnQ/bD0xIg5MaXZlIFN0cmVhbWluZ2QCAg9kFgJmDxUCFGhyZWY9ImF1ZGlvLWFyY2hpdmUiDUF1ZGlvIEFyY2hpdmVkAgMPFgIfAAIFFgpmD2QWAmYPFQIZaHJlZj0icHJpdmFjeS1wb2xpY3k/bD0xIg5Qcml2YWN5IHBvbGljeWQCAQ9kFgJmDxUCFWhyZWY9ImRpc2NsYWltZXI/bD0xIgpEaXNjbGFpbWVyZAICD2QWAmYPFQIUaHJlZj0iY29weXJpZ2h0P2w9MSIJQ29weXJpZ2h0ZAIDD2QWAmYPFQIiaHJlZj0iYWNjZXNzaWJpbGl0eS1zdGF0ZW1lbnQ/bD0xIhdBY2Nlc3NpYmlsaXR5IFN0YXRlbWVudGQCBA9kFgJmDxUCEmhyZWY9InNpdGVtYXA/bD0xIgdTaXRlbWFwZGRqnnFvvolZEioT+BxFKxhMIUAbpw==\"
+        />\r\n\r\n<input type=\"hidden\" name=\"__EVENTVALIDATION\" id=\"__EVENTVALIDATION\"
+        value=\"/wEWBgKVquebAgL3+pO+CwL3+o+/CwL3+ovECwL3+oe9CwL3+oPCC08xf3V5uEcyPgj/2AOAkgCGJ2/K\"
+        />\r\n<div id=\"topshadow\"> </div>\r\n<div id=\"contentArea\"> \r\n  \r\n
+        \ <!-- START OF HEADER -->\r\n\r\n\r\n<div id=\"header\">\r\n    <a href=\"home?l=1\"
+        title=\"Home Page\" class=\"logo\">\r\n        <img src=\"imgs/logo.gif\"
+        alt=\"Parlament Ta' Malta\" title=\"Parlament Ta' Malta Logo\"\r\n            width=\"171\"
+        height=\"92\" /></a>\r\n    <div class=\"firstRow\">\r\n        \r\n                <ul
+        class=\"sitemenu\">\r\n            \r\n                <li><a href=\"home?l=1\"=\"\">\r\n
+        \                   Home</a></li>\r\n            \r\n                <li class=\"separator\">|</li>\r\n
+        \           \r\n                <li><a href=\"contact-us?l=1\"=\"\">\r\n                    Contact
+        Us</a></li>\r\n            \r\n                <li class=\"separator\">|</li>\r\n
+        \           \r\n                <li><a href=\"sitemap?l=1\"=\"\">\r\n                    Sitemap</a></li>\r\n
+        \           \r\n                </ul>\r\n            \r\n       \r\n        \r\n
+        \      \r\n    </div>\r\n    <div class=\"secondRow\">\r\n        <a href=\"docsearch?l=1\"
+        class=\"searchButton\">\r\n            Search Site\r\n        </a>\r\n    </div>\r\n</div>\r\n\r\n
+        \ <!-- END OF HEADER --> \r\n  \r\n  <!-- MAIN CONTENT WILL BE WRAPPED IN
+        A DIV FOR ANY NECCESSARY CSS CONTROL -->\r\n  <div id=\"contentWrapper\">
+        \r\n    <!-- START OF MAIN LEFT COLUMN -->\r\n    <div id=\"mainContent\"
+        class=\"wideTemplate\">\r\n      <div id=\"mainmenu\">\r\n<ul>\r\n<li><a href=\"parliamentary-business?l=1\">Parliamentary<br
+        />Business</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a class=\"subheader\"
+        href=\"parlamentary-records?l=1\">Parliamentary Documents</a>\r\n<ul>\r\n<li><a
+        href=\"sittinglegislation?l=1\">Parliamentary sessions</a></li>\r\n<li><a
+        href=\"http://pq.gov.mt/?l=1\" target=\"_blank\">Parliamentary Questions</a></li>\r\n<li><a
+        href=\"actslegislation?l=1\">Acts of Parliament</a></li>\r\n<li><a href=\"billslegislation?l=1\">Bills</a></li>\r\n<li><a
+        href=\"paperslaidcat?l=1\">Papers laid</a></li>\r\n<li><a href=\"statementlegislation?l=1\">Ministerial
+        Statements</a></li>\r\n<li><a href=\"motionlegislation?l=1\">Motions</a></li>\r\n<li><a
+        href=\"petitionlegislation?l=1\">Petitions</a></li>\r\n<li><a href=\"rulinglegislation?l=1\">Rulings</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span
+        class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a class=\"subheader\" href=\"standing-committees?l=1\">Standing
+        Committees</a>\r\n<ul>\r\n<li><a href=\"housebusinesscommittee?l=1\">House
+        Business Committee</a></li>\r\n<li><a href=\"privilegescommittee?l=1\">Privileges
+        Committee</a></li>\r\n<li><a href=\"publicaccountscommittee?l=1\">Public Accounts
+        Committee</a></li>\r\n<li><a href=\"foreignandeuropeanaffairscommittee?l=1\">Foreign
+        and European Affairs Committee</a></li>\r\n<li><a href=\"socialaffairscommittee?l=1\">Social
+        Affairs Committee</a></li>\r\n<li><a href=\"familyaffaircommittee?l=1\">Family
+        Affairs Committee</a></li>\r\n<li><a href=\"economicandfinancialaffairscommittee?l=1\">Economic
+        and Financial Affairs Committee</a></li>\r\n<li><a href=\"healthcommittee?l=1\">Health
+        Committee</a></li>\r\n<li><a href=\"considerationofbillscommittee?l=1\">Consideration
+        of Bills Committee</a></li>\r\n<li><a href=\"nationalauditofficeaccountscommittee?l=1\">National
+        Audit Office Accounts Committee</a></li>\r\n<li><a href=\"developmentplanning?l=1\">Environment
+        and Development Planning Committee</a></li>\r\n<li><a href=\"capitalofculture?l=1\">Parliamentary
+        Group on the European Capital of Culture</a></li>\r\n<li><a href=\"adjunctconsiderationofbillscommittee?l=1\">Adjunct
+        Consideration of Bills Committee</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span
+        class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a class=\"subheader\">Select
+        Committees</a>\r\n<ul>\r\n<li><a href=\"selectcomm?l=1\">Select Committee
+        on the appointment of a commissioner and a standing committee on standards,
+        ethics and proper behaviour in public life</a></li>\r\n<li><a href=\"selcomm-11thleg?l=1\">Select
+        Committees - Archive<br /><br /></a></li>\r\n</ul>\r\n</li>\r\n<li><a class=\"subheader\"
+        href=\"parliamentary-delegations?l=1\">Parliamentary Delegations</a>\r\n<ul>\r\n<li><a
+        href=\"pace\">Parliamentary Assembly of the Council of Europe</a></li>\r\n<li><a
+        href=\"ipu\">Inter Parliamentary Union</a></li>\r\n<li><a href=\"pam\">Parliamentary
+        Assembly of the Mediterranean</a></li>\r\n<li><a href=\"paum\">Parliamentary
+        Assembly of the Union for the Mediterranean</a></li>\r\n<li><a href=\"osce\">Parliamentary
+        Assembly of the OSCE</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</div>\r\n</li>\r\n<li><a
+        href=\"about-parliament?l=1\">About<br />Parliament</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a
+        class=\"subheader\" href=\"compositionofparliament?l=1\">Composition of Parliament</a>\r\n<ul>\r\n<li><a
+        href=\"http://www.president.gov.mt/mt/Pages/default.aspx\" target=\"_blank\">The
+        President of Malta</a></li>\r\n<li><a href=\"speaker?l=1\">Mr Speaker</a></li>\r\n<li><a
+        href=\"membersofparliament?l=1\">Members of Parliament</a></li>\r\n<li><a
+        href=\"meps?l=1\">Members of European Parliament</a></li>\r\n<li><a href=\"former-mps?l=1\">Association
+        of Former Members of Parliament</a></li>\r\n<li><a href=\"formerspeakers?l=1\">Former
+        Speakers of the House of Representatives</a></li>\r\n</ul>\r\n</li>\r\n<li><a
+        class=\"subheader\" href=\"legislative-instruments?l=1\">Legislative Instruments</a>\r\n<ul>\r\n<li><a
+        href=\"constituion-of-malta?l=1\">Constitution of Malta</a></li>\r\n<li><a
+        href=\"standing-orders?l=1\">Standing Orders</a></li>\r\n<li><a href=\"house-of-representatives?l=1\">House
+        Of Representatives (Privileges and Powers) Ordinance (Cap 113)</a></li>\r\n<li><a
+        href=\"general_election_act?l=1\">General Elections Act (Cap 354)</a></li>\r\n<li><a
+        href=\"electoral-ordinance?l=1\">Electoral (Polling) Ordinance (Cap 102)</a></li>\r\n<li><a
+        href=\"mps-publicemployment?l=1\">Members of Parliament (Public Employment)
+        Act (Cap 472)</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a
+        class=\"subheader\" href=\"how-parliament-works?l=1\">How Parliament Works<br
+        /></a>\r\n<ul>\r\n<li><a href=\"historicalbackground?l=1\">Historical Background</a></li>\r\n<li><a
+        href=\"thepractiseofparliament?l=1\">Parliament Practice</a></li>\r\n<li><a
+        href=\"parliamentaryprocedures?l=1\">Parliament Procedures</a></li>\r\n<li><a
+        href=\"legislativeprocess?l=1\">Legislative Process</a></li>\r\n</ul>\r\n</li>\r\n<li><a
+        class=\"subheader\" href=\"missionstatement?l=1\">Mission Statement</a></li>\r\n<li><a
+        class=\"subheader\" href=\"objectives-responsibilities?l=1\">Objectives and
+        Responsibilities</a></li>\r\n<li><a class=\"subheader\" href=\"codeofethics?l=1\">Code
+        of Ethics</a>\r\n<ul>\r\n<li><a href=\"codeofethics-mp?l=1\">Members of Parliament</a></li>\r\n<li><a
+        href=\"codeofethics-ministers?l=1\">Ministers, Parliamentary Secretaries and
+        Parliamentary Assistants</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</div>\r\n</li>\r\n<li
+        class=\"separator\">&nbsp;</li>\r\n<li><a href=\"reference-material?l=1\">Reference<br
+        />Material</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a class=\"subheader\"
+        href=\"publications?l=1\">Publications</a>\r\n<ul>\r\n<li><a href=\"mill-parlament?l=1&quot;\">mill-Parlament
+        - Periodical</a></li>\r\n<li><a href=\"annual-reports?l=1\">Annual Report</a></li>\r\n<li><a
+        href=\"reports-parliament?l=1\">Reports published by the Speaker - 11th Legislature</a></li>\r\n<li><a
+        href=\"committee-reports?l=1\">Reports by Committees</a></li>\r\n<li><a href=\"mps-passedaway?l=1\">Commemoration
+        of Members of Parliament who passed away</a></li>\r\n<li><a href=\"health-choices\">Health
+        Choices - Proposals of the Parliamentary Working Group on Diabetes Mellitus</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n<span
+        class=\"separator\">&nbsp;</span>\r\n<ul>\r\n<li><a class=\"subheader\" href=\"related-information?l=1\">Related
+        Information</a>\r\n<ul>\r\n<li><a href=\"links?l=1\">Links</a></li>\r\n<li><a
+        href=\"fredomofinformation?l=1\">Access to Documents (Freedom of Information</a></li>\r\n<li><a
+        href=\"information-material?l=1\">Information Material</a></li>\r\n<li><a
+        href=\"memoranda-11thleg\">11th Leg Memoranda</a></li>\r\n</ul>\r\n</li>\r\n</ul>\r\n</div>\r\n</li>\r\n<li
+        class=\"separator\">&nbsp;</li>\r\n<li><a href=\"get-involved?l=1\">Get<br
+        />Involved</a>\r\n<div class=\"dropdown\">\r\n<ul>\r\n<li><a class=\"subheader\"
+        href=\"membersofparliament?l=1\">Contact Your MP</a></li>\r\n<li><a class=\"subheader\"
+        href=\"outreach-prog?l=1\">Outreach Programmes</a></li>\r\n<li><a class=\"subheader\"
+        href=\"news-events?l=1\">News and Events</a>\r\n<ul>\r\n<li><a href=\"news?l=1\">Archive</a></li>\r\n<li><a
+        href=\"press-releases?l=1\">Press Releases</a></li>\r\n</ul>\r\n</li>\r\n<li><a
+        class=\"subheader\" href=\"cultural-activities?l=1\">Cultural Activities</a></li>\r\n<li><a
+        class=\"subheader\" href=\"public-procurement\">Public Procurement</a></li>\r\n</ul>\r\n</div>\r\n</li>\r\n</ul>\r\n</div>\r\n\r\n
+        \     <div id=\"subpageContent\" class=\"oldTemplate\">\r\n        <div class=\"column1\">\r\n
+        \           \r\n<table width=\"213\" border=\"0\" cellPadding=\"0\" cellSpacing=\"0\"
+        summary=\"Design Layout\" >\r\n\t<tr>\r\n\t\t<td height=\"20\">\r\n\t\t    \r\n\t
+        \               <table width=\"212\" border=\"0\" cellPadding=\"0\" cellSpacing=\"0\"
+        summary=\"Design Layout\" >\r\n\t                <tr>\r\n\t\t                <td>\r\n\t\t
+        \                   <table width=\"212\" border=\"0\" cellPadding=\"0\" cellSpacing=\"0\"
+        id=\"submenu\" summary=\"Design Layout\">\r\n\t\t\t                    <tr>\r\n\t\t\t\t
+        \                   <td><IMG height=\"36\" src=\"imgs/tab_relatedinfo.gif\"
+        width=\"300\" alt=\"Related Info\"></td>\r\n\t\t\t                    </tr>\r\n\t\t
+        \                   </table>\r\n\t\t                </td>\r\n\t\t            </tr>\t\t
+        \           \r\n\t\t        \r\n\t\t\t\t    \r\n\t\t\t\t    <tr>\r\n\t\t\t\t
+        \       <td>\r\n\t\t\t\t\t        <table width=\"100%\" border=\"0\" cellpadding=\"0\"
+        cellspacing=\"0\" bgcolor=\"#ebebeb\" summary=\"Design Layout\">\r\n\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t\t        <tr height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t
+        \       <td width=\"27\" class=\"arrowcell\" ><img src=\"imgs/arrow_red.gif\"
+        alt=\"Arrow\" width=\"17\" height=\"13\" hspace=\"2\" vspace=\"2\"></td><td
+        align=\"left\" width=\"185\"><a class=\"MenuTextLink\" href=\"parliamentary-business?l=1\">Parliamentary
+        Business</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t        \r\n\t\t\t\t\t
+        \       </table>\r\n\t\t                </td>\r\n\t\t            </tr>\r\n\t\t\t\t\r\n\t\t\t\t
+        \   \r\n\t\t\t        <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <div
+        align=\"left\"><IMG src=\"pics/navigation_seperator.gif\" alt=\"Seperator\"
+        width=\"300\" height=\"5\"></div>\r\n\t\t\t\t        </td>\r\n\t\t\t        </tr>\r\n\t\t\t
+        \       \r\n\t\t\t\t    <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <table
+        width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" bgcolor=\"#ebebeb\"
+        summary=\"Design Layout\">\r\n\t\t\t\t\t\t        \r\n\t\t\t\t\t\t        <tr
+        height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t        <td width=\"27\" class=\"arrowcell\"
+        ><img src=\"imgs/arrow_red.gif\" alt=\"Arrow\" width=\"17\" height=\"13\"
+        hspace=\"2\" vspace=\"2\"></td><td align=\"left\" width=\"185\"><a class=\"MenuTextLink\"
+        href=\"about-parliament?l=1\">About Parliament</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t        </table>\r\n\t\t                </td>\r\n\t\t
+        \           </tr>\r\n\t\t\t\t\r\n\t\t\t\t    \r\n\t\t\t        <tr>\r\n\t\t\t\t
+        \       <td>\r\n\t\t\t\t\t        <div align=\"left\"><IMG src=\"pics/navigation_seperator.gif\"
+        alt=\"Seperator\" width=\"300\" height=\"5\"></div>\r\n\t\t\t\t        </td>\r\n\t\t\t
+        \       </tr>\r\n\t\t\t        \r\n\t\t\t\t    <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t
+        \       <table width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\"
+        bgcolor=\"#ebebeb\" summary=\"Design Layout\">\r\n\t\t\t\t\t\t        \r\n\t\t\t\t\t\t
+        \       <tr height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t        <td width=\"27\"
+        class=\"arrowcell\" ><img src=\"imgs/arrow_red.gif\" alt=\"Arrow\" width=\"17\"
+        height=\"13\" hspace=\"2\" vspace=\"2\"></td><td align=\"left\" width=\"185\"><a
+        class=\"MenuTextLink\" href=\"reference-material?l=1\">Reference Material</a></td>\r\n\t\t\t\t\t\t
+        \       </tr>\r\n\t\t\t\t\t\t\t        \r\n\t\t\t\t\t        </table>\r\n\t\t
+        \               </td>\r\n\t\t            </tr>\r\n\t\t\t\t\r\n\t\t\t\t    \r\n\t\t\t
+        \       <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <div align=\"left\"><IMG
+        src=\"pics/navigation_seperator.gif\" alt=\"Seperator\" width=\"300\" height=\"5\"></div>\r\n\t\t\t\t
+        \       </td>\r\n\t\t\t        </tr>\r\n\t\t\t        \r\n\t\t\t\t    <tr>\r\n\t\t\t\t
+        \       <td>\r\n\t\t\t\t\t        <table width=\"100%\" border=\"0\" cellpadding=\"0\"
+        cellspacing=\"0\" bgcolor=\"#ebebeb\" summary=\"Design Layout\">\r\n\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t\t        <tr height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t
+        \       <td width=\"27\" class=\"arrowcell\" ><img src=\"imgs/arrow_red.gif\"
+        alt=\"Arrow\" width=\"17\" height=\"13\" hspace=\"2\" vspace=\"2\"></td><td
+        align=\"left\" width=\"185\"><a class=\"MenuTextLink\" href=\"get-involved?l=1\">Get
+        Involved</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t        \r\n\t\t\t\t\t
+        \       </table>\r\n\t\t                </td>\r\n\t\t            </tr>\r\n\t\t\t\t\r\n\t\t\t\t
+        \   \r\n\t\t\t        <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <div
+        align=\"left\"><IMG src=\"pics/navigation_seperator.gif\" alt=\"Seperator\"
+        width=\"300\" height=\"5\"></div>\r\n\t\t\t\t        </td>\r\n\t\t\t        </tr>\r\n\t\t\t
+        \       \r\n\t\t\t\t    <tr>\r\n\t\t\t\t        <td>\r\n\t\t\t\t\t        <table
+        width=\"100%\" border=\"0\" cellpadding=\"0\" cellspacing=\"0\" bgcolor=\"#ebebeb\"
+        summary=\"Design Layout\">\r\n\t\t\t\t\t\t        \r\n\t\t\t\t\t\t        <tr
+        height=\"23\" align=\"left\">\r\n\t\t\t\t\t\t\t        <td width=\"27\" class=\"arrowcell\"
+        ><img src=\"imgs/arrow_red.gif\" alt=\"Arrow\" width=\"17\" height=\"13\"
+        hspace=\"2\" vspace=\"2\"></td><td align=\"left\" width=\"185\"><a class=\"MenuTextLink\"
+        href=\"live-parliament?l=1\">Live Parliament</a></td>\r\n\t\t\t\t\t\t        </tr>\r\n\t\t\t\t\t\t\t
+        \       \r\n\t\t\t\t\t        </table>\r\n\t\t                </td>\r\n\t\t
+        \           </tr>\r\n\t\t\t\t\r\n\t\t\t\t</table>\r\n\t\t\t\t\r\n\t\t</td>\r\n\t</tr>\r\n</table>\r\n\r\n
+        \       </div>\r\n      \t<div class=\"column2\">\r\n      \t    <h1>Hon.
+        Ian Borg MP - Parliamentary Secretary for EU funds and 2017 Presidency</h1>\r\n
+        \           <table style=\"width: 543px; height: 31px;\" border=\"0\" align=\"left\">\r\n<tbody>\r\n<tr
+        valign=\"top\">\r\n<td dir=\"ltr\" align=\"left\" valign=\"bottom\"><img title=\"Ian
+        Borg\" src=\"file.aspx?f=31734\" alt=\"Ian Borg\" width=\"167\" height=\"187\"
+        /><a id=\"irc_mil\" style=\"border-width: 0px;\" href=\"http://www.google.com.mt/url?sa=i&amp;rct=j&amp;q=konrad+mizzi&amp;source=images&amp;cd=&amp;cad=rja&amp;docid=s-SFNtregP5t8M&amp;tbnid=U6TG5-6LYAsawM:&amp;ved=0CAUQjRw&amp;url=http%3A%2F%2Felection2013.com%2Fnews%2Fitem%2F213-konrad-mizzi%3F-who%3F&amp;ei=Tfo9UbaKKsasPKLngOAI&amp;bvm=bv.43287494,d.bGE&amp;psig=AFQjCNEjypzu28wcKWQn7Izuy0urOUFdhA&amp;ust=1363102653382230\"
+        data-ved=\"0CAUQjRw\"></a><a id=\"irc_mil\" style=\"border-width: 0px;\" href=\"http://www.google.com.mt/url?sa=i&amp;rct=j&amp;q=konrad+mizzi&amp;source=images&amp;cd=&amp;cad=rja&amp;docid=s-SFNtregP5t8M&amp;tbnid=U6TG5-6LYAsawM:&amp;ved=0CAUQjRw&amp;url=http%3A%2F%2Felection2013.com%2Fnews%2Fitem%2F213-konrad-mizzi%3F-who%3F&amp;ei=Tfo9UbaKKsasPKLngOAI&amp;bvm=bv.43287494,d.bGE&amp;psig=AFQjCNEjypzu28wcKWQn7Izuy0urOUFdhA&amp;ust=1363102653382230\"
+        data-ved=\"0CAUQjRw\"></a></td>\r\n<td style=\"width: 880px;\" valign=\"bottom\">\r\n<p
+        align=\"justify\"><br /><strong>Parliamentary Group: <a onclick=\"function
+        onclick() { function onclick() { function onclick() { function onclick() {
+        function onclick() { MM_popupMsg('NOTICE: You are currently leaving the Secure
+        Government website for a 3rd Party one') } } } } }\" href=\"http://www.partitlaburista.org/\"
+        target=\"_blank\"><img title=\"Partit Laburista\" src=\"file.aspx?f=15551\"
+        alt=\"Partit Laburista\" width=\"71\" height=\"40\" /></a></strong></p>\r\n</td>\r\n</tr>\r\n<tr>\r\n<td
+        valign=\"top\"><hr /><span style=\"color: #003300;\"><strong>Contact Details:</strong></span></td>\r\n<td
+        style=\"text-align: justify;\"><hr />\r\n<p><span style=\"color: #000000;\"><strong>Address:<br
+        /></strong>Parliamentary Secretariat for EU funds and 2017 Presidency<br />Auberge
+        de Aragon</span><br /><span style=\"color: #000000;\">Valletta<strong><br
+        /><br />Tel:<br /></strong>22957422</span><strong><br /></strong><strong><br
+        /><span style=\"color: #000000;\">Email:</span><br /></strong><span style=\"color:
+        #3366ff;\"><a href=\"mailto:ian.borg@gov.mt\"><span style=\"color: #3366ff;\">ian.borg@gov.mt</span></a></span><span
+        style=\"color: #3366ff;\"><a href=\"mailto:ian.borg@gov.mt\"><br /></a><a
+        href=\"mailto:ian@ianborg.eu\"><span style=\"color: #3366ff;\">ian@ianborg.eu</span></a></span></p>\r\n<p><span
+        style=\"color: #000000;\"><strong>Website:</strong><br /><span style=\"color:
+        #3366ff;\"><a href=\"http://www.ianborg.eu\"><span style=\"color: #3366ff;\">www.ianborg.eu</span></a></span>&nbsp;<br
+        /></span></p>\r\n</td>\r\n</tr>\r\n<tr>\r\n<td valign=\"top\"><hr /><span
+        style=\"color: #003300;\"><strong>Electoral History:</strong></span></td>\r\n<td><hr
+        /><span style=\"color: #000000;\"><u><strong>Twe</strong></u><u><strong>lfth
+        Parliament:</strong></u><u><strong><br /><br /></strong></u>Elected on: 10.3.13</span><br
+        /><span style=\"color: #000000;\">Sworn in as&nbsp;Parliamentary Secretary
+        for EU funds and 2017 Presidency: 13.3.13<br /></span><span style=\"color:
+        #000000;\">Oath of Allegiance: 6.4.13</span></td>\r\n</tr>\r\n<tr>\r\n<td
+        valign=\"top\"><hr /><span style=\"color: #003300;\"><strong>European Parliamentary
+        group:</strong></span></td>\r\n<td valign=\"top\"><hr /><a onclick=\"function
+        onclick() { function onclick() { function onclick() { function onclick() {
+        function onclick() { MM_popupMsg('NOTICE: You are currently leaving the Secure
+        Government website for a 3rd Party one') } } } } }\" href=\"http://www.pes.org/\"
+        target=\"_blank\"><img title=\"PES\" src=\"file.aspx?f=15554\" alt=\"PES\"
+        width=\"27\" height=\"36\" /></a></td>\r\n</tr>\r\n</tbody>\r\n</table>\r\n
+        \     \t</div>\r\n      </div>      \r\n    </div>\r\n    <!-- END OF MAIN
+        LEFT COLUMN -->\r\n    \r\n  \r\n  <!-- #### Footer #### -->\r\n\r\n<div id=\"footer\">\r\n
+        \   <div class=\"quicknav\">\r\n        \r\n                <div class=\"menu1\">\r\n
+        \                   <h5>\r\n                        Parliamentary<br>Business</h5>\r\n
+        \                        <input type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl0:hdnID\"
+        id=\"_ctl0_footer_rpt__ctl0_hdnID\" value=\"237\" />\r\n                    \r\n
+        \                           <ul>\r\n                        \r\n                            <li><a
+        href=\"parlamentary-records?l=1\"=\"\">\r\n                                Parliamentary
+        Documents</a></li>\r\n                        \r\n                            <li><a
+        href=\"standing-committees?l=1\"=\"\">\r\n                                Standing
+        Committees</a></li>\r\n                        \r\n                            <li><a
+        href=\"http://www.parlament.mt/selcomm-11thleg?l=1\"=\"\">\r\n                                Select
+        Committees Archive</a></li>\r\n                        \r\n                            <li><a
+        href=\"http://www.parlament.mt/rulinglegislation?l=1\"=\"\">\r\n                                Rulings</a></li>\r\n
+        \                       \r\n                            <li><a href=\"plenarysession\"=\"\">\r\n
+        \                               Plenary Sessions</a></li>\r\n                        \r\n
+        \                           </ul>\r\n                        \r\n                </div>\r\n
+        \           \r\n                <div class=\"menu2\">\r\n                    <h5>\r\n
+        \                       About<br>Parliament</h5>\r\n                         <input
+        type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl1:hdnID\" id=\"_ctl0_footer_rpt__ctl1_hdnID\"
+        value=\"238\" />\r\n                    \r\n                            <ul>\r\n
+        \                       \r\n                            <li><a href=\"compositionofparliament?l=1\"=\"\">\r\n
+        \                               Composition of Parliament</a></li>\r\n                        \r\n
+        \                           <li><a href=\"legislative-instruments?l=1\"=\"\">\r\n
+        \                               Legislative Instruments</a></li>\r\n                        \r\n
+        \                           <li><a href=\"how-parliament-works?l=1\"=\"\">\r\n
+        \                               How Parliament Works</a></li>\r\n                        \r\n
+        \                           <li><a href=\"missionstatement\"=\"\">\r\n                                Mission
+        Statement</a></li>\r\n                        \r\n                            <li><a
+        href=\"objectives-responsibilities?l=1\"=\"\">\r\n                                Objectives
+        and Responsibilities</a></li>\r\n                        \r\n                            <li><a
+        href=\"codeofethics?l=1\"=\"\">\r\n                                Code of
+        Ethics</a></li>\r\n                        \r\n                            </ul>\r\n
+        \                       \r\n                </div>\r\n            \r\n                <div
+        class=\"menu3\">\r\n                    <h5>\r\n                        Reference<br>Material</h5>\r\n
+        \                        <input type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl2:hdnID\"
+        id=\"_ctl0_footer_rpt__ctl2_hdnID\" value=\"239\" />\r\n                    \r\n
+        \                           <ul>\r\n                        \r\n                            <li><a
+        href=\"publications?l=1\"=\"\">\r\n                                Publications</a></li>\r\n
+        \                       \r\n                            <li><a href=\"related-information?l=1\"=\"\">\r\n
+        \                               Related Information</a></li>\r\n                        \r\n
+        \                           </ul>\r\n                        \r\n                </div>\r\n
+        \           \r\n                <div class=\"menu4\">\r\n                    <h5>\r\n
+        \                       Get<br>Involved</h5>\r\n                         <input
+        type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl3:hdnID\" id=\"_ctl0_footer_rpt__ctl3_hdnID\"
+        value=\"240\" />\r\n                    \r\n                            <ul>\r\n
+        \                       \r\n                            <li><a href=\"membersofparliament?l=1\"=\"\">\r\n
+        \                               Contact your MP</a></li>\r\n                        \r\n
+        \                           <li><a href=\"outreach-prog?l=1\"=\"\">\r\n                                Outreach
+        Programmes</a></li>\r\n                        \r\n                            <li><a
+        href=\"news-events?l=1\"=\"\">\r\n                                News and
+        Events</a></li>\r\n                        \r\n                            <li><a
+        href=\"cultural-activities?l=1\"=\"\">\r\n                                Cultural
+        Activities</a></li>\r\n                        \r\n                            <li><a
+        href=\"public-procurement?l=1\"=\"\">\r\n                                Public
+        Procurement</a></li>\r\n                        \r\n                            </ul>\r\n
+        \                       \r\n                </div>\r\n            \r\n                <div
+        class=\"menu5\">\r\n                    <h5>\r\n                        live<br>Parliament</h5>\r\n
+        \                        <input type=\"hidden\" name=\"_ctl0:footer:rpt:_ctl4:hdnID\"
+        id=\"_ctl0_footer_rpt__ctl4_hdnID\" value=\"241\" />\r\n                    \r\n
+        \                           <ul>\r\n                        \r\n                            <li><a
+        href=\"live-parliament?l=1\"=\"\">\r\n                                Live
+        Streaming</a></li>\r\n                        \r\n                            <li><a
+        href=\"audio-archive\"=\"\">\r\n                                Audio Archive</a></li>\r\n
+        \                       \r\n                            </ul>\r\n                        \r\n
+        \               </div>\r\n            \r\n    </div>\r\n    <div class=\"footerlinks\">\r\n
+        \      \r\n        \r\n        <a href=\"privacy-policy?l=1\"=\"\">\r\n                                Privacy
+        policy</a>\r\n        \r\n        <a href=\"disclaimer?l=1\"=\"\">\r\n                                Disclaimer</a>\r\n
+        \       \r\n        <a href=\"copyright?l=1\"=\"\">\r\n                                Copyright</a>\r\n
+        \       \r\n        <a href=\"accessibility-statement?l=1\"=\"\">\r\n                                Accessibility
+        Statement</a>\r\n        \r\n        <a href=\"sitemap?l=1\"=\"\">\r\n                                Sitemap</a>\r\n
+        \       \r\n        \r\n    </div>\r\n</div>\r\n\r\n  <div id=\"alertsignature\">
+        <a href=\"http://www.alert.com.mt\">\r\n      <img id=\"_ctl0_imgAlert\" title=\"Alert
+        Logo\" src=\"imgs/design_dev_1.jpg\" border=\"0\" height=\"43\" width=\"371\"
+        /></a> </div>\r\n</div>\r\n</div>\r\n</form>\r\n</body>\r\n</html>\r\n\r\n"
+    http_version: 
+  recorded_at: Tue, 07 Feb 2017 14:39:50 GMT
+recorded_with: VCR 3.0.3

--- a/test/name_and_prefix_test.rb
+++ b/test/name_and_prefix_test.rb
@@ -12,15 +12,16 @@ describe MemberPage do
     end
 
     it 'should have a name field with the name of the member without a prefix' do
-      subject.name.must_equal 'Albert Fenech'
-    end
-
-    it 'should have an honorific_prefix field' do
-      subject.must_respond_to(:honorific_prefix)
-    end
-
-    it 'should store any titles in the honorific_prefix field' do
-      subject.honorific_prefix.must_equal 'Dr'
+      subject.to_h.must_equal(
+        id:                'fenech-albert',
+        name:              'Albert Fenech',
+        honorific_prefix:  'Dr',
+        faction:           '',
+        email:             'albert.fenech@gov.mt',
+        image:             'http://www.parlament.mt/file.aspx?f=33193',
+        source:            'http://www.parlament.mt/fenech-albert',
+        electoral_history: {}
+      )
     end
   end
 
@@ -32,12 +33,17 @@ describe MemberPage do
       MemberPage.new(response: Scraped::Request.new(url: url).response)
     end
 
-    it 'should leave a non prefixed name unchanged' do
-      subject.name.must_equal 'Ian Borg'
-    end
-
-    it 'should not return a prefix when none is present in the name' do
-      subject.honorific_prefix.must_be_empty
+    it 'should contain the expected data' do
+      subject.to_h.must_equal(
+        id:                'borg-ian',
+        name:              'Ian Borg',
+        honorific_prefix:  '',
+        faction:           'Partit Laburista',
+        email:             'ian.borg@gov.mt',
+        image:             'http://www.parlament.mt/file.aspx?f=31734',
+        source:            'http://www.parlament.mt/borg-ian',
+        electoral_history: {}
+      ).must_equal true
     end
   end
 end

--- a/test/name_and_prefix_test.rb
+++ b/test/name_and_prefix_test.rb
@@ -17,4 +17,8 @@ describe MemberPage do
   it 'should have an honorific_prefix field' do
     subject.must_respond_to(:honorific_prefix)
   end
+
+  it 'should store any titles in the honorific_prefix field' do
+    subject.honorific_prefix.must_equal 'Dr'
+  end
 end

--- a/test/name_and_prefix_test.rb
+++ b/test/name_and_prefix_test.rb
@@ -3,14 +3,11 @@ require_relative './test_helper'
 require_relative '../lib/member_page.rb'
 
 describe MemberPage do
+  subject { MemberPage.new(response: Scraped::Request.new(url: url).response) }
+  around { |test| VCR.use_cassette(url.split('/').last.split('-').map(&:capitalize).reverse.join(''), &test) }
+
   describe 'Dr Albert Fenech' do
-    around { |test| VCR.use_cassette('AlbertFenech', &test) }
-
-    subject do
-      url = 'http://www.parlament.mt/fenech-albert'
-      MemberPage.new(response: Scraped::Request.new(url: url).response)
-    end
-
+    let(:url) { 'http://www.parlament.mt/fenech-albert' }
     it 'should have a name field with the name of the member without a prefix' do
       subject.to_h.must_equal(
         id:                'fenech-albert',
@@ -26,12 +23,7 @@ describe MemberPage do
   end
 
   describe 'Ian Borg' do
-    around { |test| VCR.use_cassette('IanBorg', &test) }
-
-    subject do
-      url = 'http://www.parlament.mt/borg-ian'
-      MemberPage.new(response: Scraped::Request.new(url: url).response)
-    end
+    let(:url) { 'http://www.parlament.mt/borg-ian' }
 
     it 'should contain the expected data' do
       subject.to_h.must_equal(
@@ -43,7 +35,7 @@ describe MemberPage do
         image:             'http://www.parlament.mt/file.aspx?f=31734',
         source:            'http://www.parlament.mt/borg-ian',
         electoral_history: {}
-      ).must_equal true
+      )
     end
   end
 end

--- a/test/name_and_prefix_test.rb
+++ b/test/name_and_prefix_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require_relative './test_helper'
+require_relative '../lib/member_page.rb'
+
+describe MemberPage do
+  around { |test| VCR.use_cassette('AlbertFenech', &test) }
+
+  subject do
+    url = 'http://www.parlament.mt/fenech-albert'
+    MemberPage.new(response: Scraped::Request.new(url: url).response)
+  end
+
+  it 'should have a name field with the name of the member without a prefix' do
+    subject.name.must_equal 'Albert Fenech'
+  end
+end

--- a/test/name_and_prefix_test.rb
+++ b/test/name_and_prefix_test.rb
@@ -13,4 +13,8 @@ describe MemberPage do
   it 'should have a name field with the name of the member without a prefix' do
     subject.name.must_equal 'Albert Fenech'
   end
+
+  it 'should have an honorific_prefix field' do
+    subject.must_respond_to(:honorific_prefix)
+  end
 end

--- a/test/name_and_prefix_test.rb
+++ b/test/name_and_prefix_test.rb
@@ -3,22 +3,41 @@ require_relative './test_helper'
 require_relative '../lib/member_page.rb'
 
 describe MemberPage do
-  around { |test| VCR.use_cassette('AlbertFenech', &test) }
+  describe 'Dr Albert Fenech' do
+    around { |test| VCR.use_cassette('AlbertFenech', &test) }
 
-  subject do
-    url = 'http://www.parlament.mt/fenech-albert'
-    MemberPage.new(response: Scraped::Request.new(url: url).response)
+    subject do
+      url = 'http://www.parlament.mt/fenech-albert'
+      MemberPage.new(response: Scraped::Request.new(url: url).response)
+    end
+
+    it 'should have a name field with the name of the member without a prefix' do
+      subject.name.must_equal 'Albert Fenech'
+    end
+
+    it 'should have an honorific_prefix field' do
+      subject.must_respond_to(:honorific_prefix)
+    end
+
+    it 'should store any titles in the honorific_prefix field' do
+      subject.honorific_prefix.must_equal 'Dr'
+    end
   end
 
-  it 'should have a name field with the name of the member without a prefix' do
-    subject.name.must_equal 'Albert Fenech'
-  end
+  describe 'Ian Borg' do
+    around { |test| VCR.use_cassette('IanBorg', &test) }
 
-  it 'should have an honorific_prefix field' do
-    subject.must_respond_to(:honorific_prefix)
-  end
+    subject do
+      url = 'http://www.parlament.mt/borg-ian'
+      MemberPage.new(response: Scraped::Request.new(url: url).response)
+    end
 
-  it 'should store any titles in the honorific_prefix field' do
-    subject.honorific_prefix.must_equal 'Dr'
+    it 'should leave a non prefixed name unchanged' do
+      subject.name.must_equal 'Ian Borg'
+    end
+
+    it 'should not return a prefix when none is present in the name' do
+      subject.honorific_prefix.must_be_empty
+    end
   end
 end


### PR DESCRIPTION
This is a step towards scraping members who have left the legislature, along with their end dates. (Issue: https://github.com/everypolitician/everypolitician-data/issues/25279)

Some member names are displayed along with their titles.

![screen shot 2017-01-30 at 16 08 40](https://cloud.githubusercontent.com/assets/4107953/22430508/6c9607d4-e706-11e6-806a-b535c8d6a48f.png)

This PR separates the title from the name. It adds the field `:honorific_prefix`